### PR TITLE
Support a single nutrient to be excluded when mode is not nutrient to set a nutrient to ignore from all

### DIFF
--- a/src/main/java/ca/wescook/nutrition/effects/EffectsList.java
+++ b/src/main/java/ca/wescook/nutrition/effects/EffectsList.java
@@ -44,9 +44,11 @@ public class EffectsList {
 			effect.maximum = effectRaw.maximum;
 			effect.detect = effectRaw.detect;
 
-			// Assigning appropriate nutrient
+			// assign the tag for exclusion/only nutrient
+			effect.nutrient = NutrientList.getByName(effectRaw.nutrient);
+			
+			// error if missing the nutrient when the mode is nutrient
 			if (effect.detect.equals("nutrient")) {
-				effect.nutrient = NutrientList.getByName(effectRaw.nutrient);
 				if (effect.nutrient == null) {
 					Log.error("Detect mode is set to 'nutrient', but nutrient is not set. (" + effect.name + ")");
 					continue;

--- a/src/main/java/ca/wescook/nutrition/effects/EffectsManager.java
+++ b/src/main/java/ca/wescook/nutrition/effects/EffectsManager.java
@@ -41,7 +41,8 @@ public class EffectsManager {
 					// Loop all nutrients
 					for (Map.Entry<Nutrient, Float> entry : playerNutrition.entrySet()) {
 						// If any are found within threshold
-						if (entry.getValue() >= effect.minimum && entry.getValue() <= effect.maximum) {
+						if (!entry.getKey().equals(effect.nutrient) // skip if excluded
+								&& entry.getValue() >= effect.minimum && entry.getValue() <= effect.maximum) {
 							effectsInThreshold.add(effect); // Add effect, once
 							break;
 						}
@@ -55,11 +56,18 @@ public class EffectsManager {
 					total = 0f;
 
 					// Loop all nutrients
-					for (Map.Entry<Nutrient, Float> entry : playerNutrition.entrySet())
-						total += entry.getValue(); // Add each value to total
+					for (Map.Entry<Nutrient, Float> entry : playerNutrition.entrySet()) {
+						if(!entry.getKey().equals(effect.nutrient)) // skip if excluded
+							total += entry.getValue(); // Add each value to total
+					}
 
+					// remove the excluded nutrient from the size count
+					int size = playerNutrition.size();
+					if(effect.nutrient != null) {
+						size--;
+					}
 					// Divide by number of nutrients for average (division by zero check)
-					average = (playerNutrition.size() != 0) ? total / playerNutrition.size() : -1f;
+					average = (size != 0) ? total / size : -1f;
 
 					// Check average is inside the threshold
 					if (average >= effect.minimum && average <= effect.maximum)
@@ -74,7 +82,8 @@ public class EffectsManager {
 
 					// Loop all nutrients
 					for (Map.Entry<Nutrient, Float> entry : playerNutrition.entrySet()) {
-						if (!(entry.getValue() >= effect.minimum && entry.getValue() <= effect.maximum)) // If nutrient isn't within threshold
+						if (!entry.getKey().equals(effect.nutrient) // skip if excluded
+								&& !(entry.getValue() >= effect.minimum && entry.getValue() <= effect.maximum)) // If nutrient isn't within threshold
 							allWithinThreshold = false; // Fail check
 					}
 
@@ -92,7 +101,8 @@ public class EffectsManager {
 					// Loop all nutrients
 					for (Map.Entry<Nutrient, Float> entry : playerNutrition.entrySet()) {
 						// If any are found within threshold
-						if (entry.getValue() >= effect.minimum && entry.getValue() <= effect.maximum)
+						if (!entry.getKey().equals(effect.nutrient) // skip if excluded
+								&& entry.getValue() >= effect.minimum && entry.getValue() <= effect.maximum)
 							cumulativeCount++;
 					}
 

--- a/src/main/resources/assets/nutrition/configs/effects/example.json
+++ b/src/main/resources/assets/nutrition/configs/effects/example.json
@@ -11,5 +11,6 @@
 	                                  //   'cumulative': For each nutrient within the threshold, the amplifier increases by one
 	                                  //   'nutrient': A specific nutrient must be in the threshold (see below)
 	"nutrient": "",                   // If detect=nutrient, this defines the nutrient ID checked against
+	                                  // If detect!=nutrient, this defines the nutrient ID that is excluded from the average or threshold
 	"enabled": false                  // Will this effect be active or not
 }


### PR DESCRIPTION
If the mode is `any`, `cumulative`, `average`, or `all`, the `nutrients` tag can be set to string to denote a nutrient that is not part of that operation. I decided to reuse the nutrients tag from `detect=nutrient` as you never set both of them at the same time, and it seemed a little cleaner to not always have a tag that does nothing.

If you would prefer it to be separate tags to be slightly easier to understand, I'll gladly split the functionality to an `excludeNutrient` tag.