### PR TITLE
Generic support for drinkable items

### DIFF
--- a/src/main/java/ca/wescook/nutrition/capabilities/CapImplementation.java
+++ b/src/main/java/ca/wescook/nutrition/capabilities/CapImplementation.java
@@ -18,6 +18,7 @@ public class CapImplementation implements CapInterface {
 	// Map Nutrient type to value for that nutrient
 	private Map<Nutrient, Float> playerNutrition = new HashMap<>();
 	private EntityPlayer player;
+	private Float playerDrinkPenalty;
 
 	CapImplementation(EntityPlayer player) {
 		// Store player
@@ -26,6 +27,9 @@ public class CapImplementation implements CapInterface {
 		// Populate nutrient data with starting nutrition
 		for (Nutrient nutrient : NutrientList.get())
 			playerNutrition.put(nutrient, (float) Config.startingNutrition);
+		
+		// Assign starting drink penalty
+		playerDrinkPenalty = (float) Config.startingDrinkPenalty;
 	}
 
 	public Map<Nutrient, Float> get() {
@@ -81,5 +85,14 @@ public class CapImplementation implements CapInterface {
 	public void resync() {
 		if (!player.world.isRemote)
 			ModPacketHandler.NETWORK_CHANNEL.sendTo(new PacketNutritionResponse.Message(player), (EntityPlayerMP) player);
+	}
+	
+	public Float getDrinkPenalty() {
+		return playerDrinkPenalty;
+	}
+	
+	public void setDrinkPenalty(Float value, boolean sync) {
+		playerDrinkPenalty = value;
+		if (sync) resync();
 	}
 }

--- a/src/main/java/ca/wescook/nutrition/capabilities/CapInterface.java
+++ b/src/main/java/ca/wescook/nutrition/capabilities/CapInterface.java
@@ -36,4 +36,10 @@ public interface CapInterface {
 
 	// Sync nutrition data to local dummy
 	void resync();
+	
+	// Return drink penalty
+	Float getDrinkPenalty();
+	
+	// Set drink penalty
+	void setDrinkPenalty(Float value, boolean sync);
 }

--- a/src/main/java/ca/wescook/nutrition/capabilities/CapStorage.java
+++ b/src/main/java/ca/wescook/nutrition/capabilities/CapStorage.java
@@ -12,12 +12,15 @@ import java.util.HashMap;
 
 // Saves and loads serialized data from disk
 public class CapStorage implements Capability.IStorage<CapInterface> {
+	private static final String DRINK_PENALTY_STRING = "drinkPenalty";
+	
 	// Save serialized data to disk
 	@Override
 	public NBTBase writeNBT(Capability<CapInterface> capability, CapInterface instance, EnumFacing side) {
 		NBTTagCompound playerData = new NBTTagCompound();
 		for (Nutrient nutrient : NutrientList.get())
 			playerData.setFloat(nutrient.name, instance.get(nutrient));
+		playerData.setFloat(DRINK_PENALTY_STRING, instance.getDrinkPenalty());
 		return playerData;
 	}
 
@@ -41,5 +44,12 @@ public class CapStorage implements Capability.IStorage<CapInterface> {
 		// Replace nutrient data with map
 		// Note: Syncing throws network errors at this stage
 		instance.set(clientNutrients, false);
+
+		// Read drink penalty from file
+		if (((NBTTagCompound) nbt).hasKey(DRINK_PENALTY_STRING))
+			value = ((NBTTagCompound) nbt).getFloat(DRINK_PENALTY_STRING);
+		else
+			value = (float) 0; //TODO use config for default
+		instance.setDrinkPenalty(value, false);
 	}
 }

--- a/src/main/java/ca/wescook/nutrition/events/EventPlayerUpdate.java
+++ b/src/main/java/ca/wescook/nutrition/events/EventPlayerUpdate.java
@@ -27,6 +27,9 @@ public class EventPlayerUpdate {
 		// Apply decay check each tick
 		if (Config.enableDecay)
 			nutritionDecay(player);
+		
+		// Reduce drink penalty each tick
+		drinkPenaltyTick(player);
 
 		// Reapply potion effects every 5 seconds
 		if (potionCounter > 100) {
@@ -55,5 +58,13 @@ public class EventPlayerUpdate {
 
 		// Update for the next pass
 		playerFoodLevels.put(player, foodLevelNew);
+	}
+	
+	private void drinkPenaltyTick(EntityPlayer player) {
+		Float drinkPenalty = player.getCapability(CapProvider.NUTRITION_CAPABILITY, null).getDrinkPenalty();
+		drinkPenalty--;
+		if (drinkPenalty < 0)
+			drinkPenalty = (float) 0;
+		player.getCapability(CapProvider.NUTRITION_CAPABILITY, null).setDrinkPenalty(drinkPenalty, true);
 	}
 }

--- a/src/main/java/ca/wescook/nutrition/utility/Config.java
+++ b/src/main/java/ca/wescook/nutrition/utility/Config.java
@@ -33,13 +33,14 @@ public class Config {
 	public static int lossPerNutrient;
 	public static float nutritionMultiplier;
 	public static int startingNutrition;
+	public static int maxDrinkFoodValue;
+	public static int maxDrinkPenalty;
+	public static int startingDrinkPenalty;
 	public static boolean enableGui;
 	public static boolean enableGuiButton;
 	public static boolean enableTooltips;
 	public static int buttonXPosition;
 	public static int buttonYPosition;
-	public static String buttonOrigin;
-	public static String buttonAnchor;
 	public static boolean logMissingFood;
 	public static boolean logMissingNutrients;
 
@@ -77,8 +78,7 @@ public class Config {
 		decayMultiplier = configFile.getFloat("DecayMultiplier", CATEGORY_DECAY, 1, -100, 100, "Global value to multiply decay rate by (eg. 0.5 halves the rate, 2.0 doubles it).  This can also be set per-nutrient.");
 
 		deathPenaltyMin = configFile.getInt("DeathPenaltyMin", CATEGORY_DEATH_PENALTY, 30, 0, 100, "The minimum nutrition value that the death penalty may reduce to.");
-		deathPenaltyReset = configFile.getBoolean("DeathPenaltyReset", CATEGORY_DEATH_PENALTY, true, "On death, should nutrition be reset to DeathPenaltyMin if it's fallen below that value?\n" +
-			"This is recommended to prevent death loops caused by negative effects.");
+		deathPenaltyReset = configFile.getBoolean("DeathPenaltyReset", CATEGORY_DEATH_PENALTY, true, "On death, should nutrition be reset to DeathPenaltyMin if it's fallen below that value?  This is recommended to prevent death loops caused by negative effects.");
 		deathPenaltyLoss = configFile.getInt("DeathPenaltyLoss", CATEGORY_DEATH_PENALTY, 15, 0, 100, "The nutrition value subtracted from each nutrient upon death.");
 
 		nutritionMultiplier = configFile.getFloat("NutritionMultiplier", CATEGORY_NUTRITION, 1, 0, 100, "Value to multiply base nutrition by for each food (eg. 0.5 to halve nutrition gain).");
@@ -90,15 +90,15 @@ public class Config {
 		allowOverEating = configFile.getBoolean("AllowOverEating", CATEGORY_NUTRITION, false, "Allow player to continue eating even while full.\n" +
 			"This setting may upset balance, but is necessary for playing in peaceful mode.");
 
+		maxDrinkFoodValue = configFile.getInt("MaxDrinkFoodValue", CATEGORY_NUTRITION, 8, 0, 100, "Base nutrition value for drinkable items that do not grant food haunches (eg. Milk). This value is reduced after a drink is consumed and gradually returns to full value after a delay. Also affected by NutritionMultiplier.");
+		maxDrinkPenalty = configFile.getInt("MaxDrinkPenalty", CATEGORY_NUTRITION, 12000, 0, 24000*30, "Number of game ticks players should wait to get maximum food value from drinks, where 24000 is one Minecraft day (bigger values make drinks worse for nutrition).");
+		startingDrinkPenalty = configFile.getInt("startingDrinkPenalty", CATEGORY_NUTRITION, 0, 0, 24000*30, "The starting drink penalty for players, in game ticks.");
+		
 		enableGui = configFile.getBoolean("EnableGui", CATEGORY_GUI, true, "If the nutrition GUI should be enabled");
 		enableGuiButton = configFile.getBoolean("EnableGuiButton", CATEGORY_GUI, true, "If the nutrition button should be shown on player inventory (hotkey will still function).");
 		enableTooltips = configFile.getBoolean("EnableTooltips", CATEGORY_GUI, true, "If foods should show their nutrients on hover.");
-		buttonOrigin = configFile.getString("ButtonOrigin", CATEGORY_GUI, "gui", "The origin defines the object which the nutrition button will be placed relative to.\n" +
-			"Accepted values: gui, screen");
-		buttonAnchor = configFile.getString("ButtonAnchor", CATEGORY_GUI, "top-left", "The anchor defines which side of the origin to position the button against.\n" +
-			"Accepted values: top, right, bottom, left, top-left, top-right, bottom-right, bottom-left, center");
-		buttonXPosition = configFile.getInt("ButtonXPosition", CATEGORY_GUI, 134, -1000, 1000, "The nutrition button's X position, relative to its anchor point.");
-		buttonYPosition = configFile.getInt("ButtonYPosition", CATEGORY_GUI, 61, -1000, 1000, "The nutrition button's Y position, relative to its anchor point.");
+		buttonXPosition = configFile.getInt("ButtonXPosition", CATEGORY_GUI, 134, 0, 500, "The nutrition button's X position.");
+		buttonYPosition = configFile.getInt("ButtonYPosition", CATEGORY_GUI, 61, 0, 500, "The nutrition button's Y position.");
 
 		logMissingFood = configFile.getBoolean("LogMissingFood", CATEGORY_LOGGING, false, "Log foods which have not been registered but are still listed in nutrients.");
 		logMissingNutrients = configFile.getBoolean("LogMissingNutrients", CATEGORY_LOGGING, false, "Log foods which are registered but do not have any nutrients.");


### PR DESCRIPTION
Allows drinkable items to grant nutrients. I added this capability primarily to support Tough As Nails juices (which are not ItemFood, they only grant TAN thirst points), but as a positive side effect it captures vanilla milk buckets.

Milk buckets have the problem that they are infinitely use-able. Players could grind out dairy points by sitting next to a cow for 10 minutes - not great gameplay. To combat this I added a player statistic, "drink penalty", that is global for all drinkable items. After drinking something, the stat gets set to its maximum number (I just used ticks) and drops over time - if you drink many items in quick succession, you'll get nothing except from the first drink.

The food value for any given drink is calculated by multiplying a max (8) with a percentage, which is close to 0 when the drink penalty is near its max, and close to 1 when the drink penalty is near 0. The percentage follows a logarithmic function, so the percentage rises slowly at first, then accelerates steeply, then approaches 1 slowly again at the end.

Also, looks like my changes clobbered some new additions to the configs.